### PR TITLE
AirDC path no longer forced on grab

### DIFF
--- a/mylar/downloaders/airdcpp.py
+++ b/mylar/downloaders/airdcpp.py
@@ -404,8 +404,6 @@ class AirDCPP(object):
                 search_instance_id = self.current_search_instance_id
 
             payload = {
-                "target_directory": dl_location,
-                "target_name": filename,
                 "priority": 4
             }
 


### PR DESCRIPTION
Current implementation passes the AirDC++ download location to AirDC++ manually, this causes pathing issues with Windows installs of AirDC (see discord conversation in #support on April 6th 2026). The two payload attributes `target_name` and `target_directory` are optional and default to using `filename` and `dl_location` by default. With the translation via API of `/` to `_` this results in the first image below as filename and attempt to create an invalid file on the windows install.
 
<img width="882" height="50" alt="image" src="https://github.com/user-attachments/assets/d3550a23-bc4a-40b3-b378-136b0b478e00" />

By leaving these payload items out, we're allowing AirDC to manage where the files go within its system and to pass along the resulting file to Mylar where we already account for the system path differences in the function `download` on what is now line `391`.

Reference docs/endpoint screenshot for easy verification. [API Doc on endpoint](https://airdcpp.docs.apiary.io/#reference/search-instances/results/download-result) <img width="847" height="645" alt="Screenshot_20260406_102443" src="https://github.com/user-attachments/assets/f2aa8bf7-e1d4-48de-ae0b-d563ec0df6a0" />