### PR TITLE
Check Story Arc Issues by ID First

### DIFF
--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -5391,6 +5391,50 @@ class WebInterface(object):
 
                 matcheroso = "no"
 
+                # First try matching by IDs in the existing DB
+                if mylar.CONFIG.ANNUALS_ON:
+                    comics_by_id = myDB.select(
+                        "SELECT c.comicid, comicyear, comiclocation, issueid, True as match_annual \
+                            FROM comics c LEFT JOIN annuals a ON c.comicid=a.comicid \
+                            WHERE a.releasecomicid=? AND a.issueid=? \
+                        UNION SELECT c.comicid, comicyear, comiclocation, issueid, False as match_annual \
+                            FROM comics c LEFT JOIN issues i ON c.comicid=i.comicid \
+                            WHERE c.comicid=? AND i.issueid=?",
+                        [arc['ComicID'], arc['IssueID'], arc['ComicID'], arc['IssueID']]
+                    )
+                else:
+                    comics_by_id = myDB.select(
+                        "SELECT c.comicid, comicyear, comiclocation, issueid, False as match_annual \
+                            FROM comics c LEFT JOIN issues i ON c.comicid=i.comicid \
+                            WHERE c.comicid=? AND i.issueid=?",
+                        [arc['ComicID'], arc['IssueID']]
+                    )
+                for comic_by_id in comics_by_id:
+                    logger.fdebug('issue #: %s is present!' % arc['IssueNumber'])
+                    logger.fdebug('Comicname: %s' % arc['ComicName'])
+                    logger.fdebug('ComicID: %s [IssueID: %s]' % (comic_by_id['comicid'], comic_by_id['issueid']))
+                    logger.fdebug('Issue: %s' % arc['IssueNumber'])
+                    logger.fdebug('IssueArcID: %s' % arc['IssueArcID'])
+                    #gather the matches now.
+                    arc_match.append({
+                        "match_storyarc":          arc['StoryArc'],
+                        "match_annual":            comic_by_id['match_annual'],
+                        "match_name":              arc['ComicName'],
+                        "match_id":                comic_by_id['comicid'],
+                        "match_issueid":           comic_by_id['issueid'],
+                        "match_issue":             arc['IssueNumber'],
+                        "match_issuearcid":        arc['IssueArcID'],
+                        "match_seriesyear":        comic_by_id['comicyear'],
+                        "match_readingorder":      arc['ReadingOrder'],
+                        "match_filedirectory":     comic_by_id['comiclocation'],   #series directory path
+                        "destination_location":    dstloc})                  #path to given storyarc / grab-bag directory
+                    matcheroso = "yes"
+                    break
+                if matcheroso == "yes":
+                    # if there are any results by id, we have a mactch and can continue to the next issue
+                    continue
+
+                # If we fail to find the comic by ID, fall back to looking by name
                 dyn_name = arc['DynamicComicName']
                 dyn_name = re.sub(r'[\|\s]','', dyn_name.lower()).strip()
                 if mylar.CONFIG.ANNUALS_ON:

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -5409,13 +5409,11 @@ class WebInterface(object):
                             WHERE c.comicid=? AND i.issueid=?",
                         [arc['ComicID'], arc['IssueID']]
                     )
-                for comic_by_id in comics_by_id:
-                    logger.fdebug('issue #: %s is present!' % arc['IssueNumber'])
-                    logger.fdebug('Comicname: %s' % arc['ComicName'])
-                    logger.fdebug('ComicID: %s [IssueID: %s]' % (comic_by_id['comicid'], comic_by_id['issueid']))
-                    logger.fdebug('Issue: %s' % arc['IssueNumber'])
-                    logger.fdebug('IssueArcID: %s' % arc['IssueArcID'])
-                    #gather the matches now.
+                if comics_by_id:
+                    if len(comics_by_id) > 1:
+                        # If we find more than one issue, log a warning but continue, using the first result
+                        logger.warn("found more than one copy of issue %s, likely because it is added both via annual integration and independently" % (arc['IssueID']))
+                    comic_by_id = comics_by_id[0]
                     arc_match.append({
                         "match_storyarc":          arc['StoryArc'],
                         "match_annual":            comic_by_id['match_annual'],
@@ -5428,10 +5426,7 @@ class WebInterface(object):
                         "match_readingorder":      arc['ReadingOrder'],
                         "match_filedirectory":     comic_by_id['comiclocation'],   #series directory path
                         "destination_location":    dstloc})                  #path to given storyarc / grab-bag directory
-                    matcheroso = "yes"
-                    break
-                if matcheroso == "yes":
-                    # if there are any results by id, we have a mactch and can continue to the next issue
+                    # Since we found the result by id, we can continue to the next issue
                     continue
 
                 # If we fail to find the comic by ID, fall back to looking by name


### PR DESCRIPTION
Note - this is a port of a pull request from the old repo.

When looking up story arc issues, mylar checks via a complex system based on name lookup. For annuals, if the annual isn't a fixed pattern, this can and will miss issues. Since we have all of the IDs necessary, we can instead just query the DB by IDs, which is more accurate and faster. If this doesn't find the issue, the old code remains in place as the fallback.

I tested this on story arcs where annuals are cleanly tied to their parent series, and story arcs where the annual was tied to a differently named parent series. I also tested story arcs where some annuals were added directly as series rather than tied to the series. With this fix, all of these cases worked. Without this fix, only annuals that matched the parent comic's name and were added as annuals would match.

I also tested with annual integration turned off, and this behaved as expected.

Since I opened the original PR on the old repo, I have been running this locally for a while with no issues.