### PR TITLE
Add option to use curl_cffi to bypass Cloudflare

### DIFF
--- a/mylar/config.py
+++ b/mylar/config.py
@@ -380,6 +380,7 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'JD2_ENABLE': (bool, 'DDL', False),
     'JD2_DEST_DIR': (str, 'DDL', None),
     'JD2_URL': (str, 'DDL', None),
+    'USE_CURL_CFFI': (bool, 'DDL', False),
 
     'ENABLE_AIRDCPP': (bool, 'DCPP', False),
     'AIRDCPP_HOST': (str, 'DCPP', ""),

--- a/mylar/getcomics.py
+++ b/mylar/getcomics.py
@@ -25,13 +25,13 @@ import re
 import time
 import datetime
 from bs4 import BeautifulSoup
-import requests
 import zipfile
 import json
 import mylar
 from operator import itemgetter
 from mylar import db, logger, helpers, search_filer
 from mylar.downloaders.jdownloader2 import JDownloader2
+import curl_cffi
 
 class GC(object):
 
@@ -134,7 +134,11 @@ class GC(object):
             'Referer': mylar.GC_URL,
         }
 
-        self.session = requests.Session()
+        if mylar.CONFIG.USE_CURL_CFFI:
+            logger.fdebug('[DDL] Using curl_cffi for GetComics')
+            self.session = curl_cffi.Session(impersonate="chrome")
+        else:
+            self.session = requests.Session()
 
         if mylar.CONFIG.ENABLE_PROXY:
             self.session.proxies.update({

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ tenacity>=8.2.3
 tzlocal>=2.0.0
 urllib3<2
 user_agent2>=2021.12.11
+curl_cffi>=0.14.0


### PR DESCRIPTION
With Python > 3.12, using flaresolverr to bypass Cloudflare restrictions no longer works. The most widely suggested alternative is to use `curl_cffi` as a drop-in replacement for the standard `requests` library.

This PR implements `curl_cffi` as an optional alternative to `requests`. If the new option `USE_CURL_CFFI` is set to `True`, Mylar will create a `Session` object using curl_cffi set to impersonate a Chrome browser. If it's set to `False`, it will use `requests` to create the `Session`. Once created, the `Session` object works the same regardless of which backend was chosen.

`USE_CURL_CFFI` is disabled by default, but can be enabled via `config.ini`. For users who don't want it, the change should be invisible.

I've tested this on Docker (using the [linuxserver.io build scripts](https://github.com/linuxserver/docker-mylar3/tree/nightly)) and in native builds for Windows, macOS, and Alpine Linux using Python 3.14. All versions build and operate as expected.

(Note: I also removed a duplicate `import requests` from `getcomics.py` line 28. `requests` is still included at line 18.)