### PR TITLE
fix: prevent unnecessary reloads on every message

### DIFF
--- a/data/interfaces/default/base.html
+++ b/data/interfaces/default/base.html
@@ -362,7 +362,7 @@
                     if (data.status == 'success'){
                         $('#ajaxMsg').addClass('success').fadeIn().delay(3000).fadeOut();
                         console.log('data.comicid:'+data.comicid)
-                        if ( ( tt.value != "config" ) && ( tt.value != "cblimport") && (data.tables == 'both' || data.tables == 'tables') && ( document.body.innerHTML.search(data.comicid) || tt.value == "history" || tt.value == "search_results") ){
+                        if ( ( tt.value != "config" ) && ( tt.value != "cblimport") && (data.tables == 'both' || data.tables == 'tables') && ( document.body.innerHTML.search(data.comicid) != -1 || tt.value == "history" || tt.value == "search_results") ){
                             console.log('reloading table1...');
                             reload_table();
                         }


### PR DESCRIPTION
This should prevent those message box popups on the home screen.  They're a product of datatables + the notification system forcing table reloads before they've been properly configured, along with a very old bug where this was clearly meant to check whether the comicid was somewhere in the page source, except that -1 is truthy in javascript so it triggered on EVERYTHING.