### PR TITLE
fix(history): prevent clear status being set when using markissues in history

### DIFF
--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -2378,6 +2378,7 @@ class WebInterface(object):
                     logger.fdebug("Marking " + str(IssueID) + " as Skipped")
                 elif action == 'Clear':
                     myDB.action("DELETE FROM snatched WHERE IssueID=?", [IssueID])
+                    continue
                 elif action == 'Failed' and mylar.CONFIG.FAILED_DOWNLOAD_HANDLING:
                     logger.fdebug('Marking [' + comicname + '] : ' + str(IssueID) + ' as Failed. Sending to failed download handler.')
                     failedcomicid = mi['ComicID']


### PR DESCRIPTION
Strange little corner case where the value "Clear" was getting set to issue statuses if you use something that nobody uses.  Really shouldn't be being handled in that function anyway, but there it is.  Now skips the issue upsert if the action is "Clear".