### PR TITLE
Fix CarePackage webhook redaction

### DIFF
--- a/mylar/carepackage.py
+++ b/mylar/carepackage.py
@@ -52,6 +52,8 @@ class carePackage(object):
                             ('PUSHBULLET', 'pushbullet_apikey'),
                             ('NMA', 'nma_apikey'),
                             ('TELEGRAM', 'telegram_token'),
+                            ('SLACK', 'slack_webhook_url'),
+                            ('MATTERMOST', 'mattermost_webhook_url'),
                             ('GOTIFY', 'gotify_token'),
                             ('CV', 'comicvine_api'),
                             ('Seedbox', 'seedbox_user'),


### PR DESCRIPTION
Fixes #18

## Summary
- add the Slack webhook URL to the CarePackage config redaction list
- add the Mattermost webhook URL as the same class of notification webhook secret
- keep the change limited to `clean_config.ini` redaction metadata; no notification behavior changes

## Verification
- `python3 -m py_compile mylar/carepackage.py`
- local ConfigParser simulation confirmed Slack, Mattermost, and existing Discord webhook values are replaced with `xXX[REMOVED]XXx`
- `git diff --check`

Safety: public-code-only fix using fake/example webhook values only; no real tokens, webhooks, private care packages, account access, spend, deploys, or external service calls.
