### PR TITLE
fix: redact Slack and Mattermost webhooks in CarePackage

### DIFF
--- a/mylar/carepackage.py
+++ b/mylar/carepackage.py
@@ -64,6 +64,8 @@ class carePackage(object):
                             ('AutoSnatch', 'pp_sshport'),
                             ('Email', 'email_password'),
                             ('Email', 'email_user'),
+                            ('SLACK', 'slack_webhook_url'),
+                            ('MATTERMOST', 'mattermost_webhook_url'),
                             ('DISCORD', 'discord_webhook_url'),
                             ('DDL', 'external_username'),
                             ('DDL', 'external_apikey'),

--- a/tests/test_carepackage_redaction.py
+++ b/tests/test_carepackage_redaction.py
@@ -1,0 +1,25 @@
+import ast
+from pathlib import Path
+
+
+def _cleaned_list_entries():
+    source = Path("mylar/carepackage.py").read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Attribute) and target.attr == "cleaned_list":
+                    return {
+                        tuple(elt.value for elt in entry.elts)
+                        for entry in node.value.elts
+                        if isinstance(entry, ast.Tuple)
+                    }
+    raise AssertionError("carePackage.cleaned_list assignment not found")
+
+
+def test_carepackage_redacts_slack_and_mattermost_webhook_urls():
+    cleaned_list = _cleaned_list_entries()
+
+    assert ("SLACK", "slack_webhook_url") in cleaned_list
+    assert ("MATTERMOST", "mattermost_webhook_url") in cleaned_list
+    assert ("DISCORD", "discord_webhook_url") in cleaned_list


### PR DESCRIPTION
## Summary
- add Slack and Mattermost webhook URLs to the existing CarePackage redaction allowlist
- add a regression test that keeps Slack, Mattermost, and Discord webhook fields covered together

## Verification
- [x] `python3 -m pytest tests/test_carepackage_redaction.py -q`
- [x] `python3 -m py_compile mylar/carepackage.py`
- [x] `git diff --check`

Closes #18
