### PR TITLE
fix: fix the week info calculation to be wednesday centered week numbering aligned with talkhard

### DIFF
--- a/data/interfaces/default/weeklypull.html
+++ b/data/interfaces/default/weeklypull.html
@@ -57,7 +57,7 @@
            <table width="100%" align="center">
              <tr>
               <td style="vertical-align: middle; text-align: right">
-                  <a href="pullist?week=${weekinfo['prev_weeknumber']}&year=${weekinfo['prev_year']}&current=${weekinfo['weeknumber']}-${weekinfo['year']}" title="Previous Week (${weekinfo['prev_weeknumber']})" onclick="arrows_page();">
+                  <a href="pullist?week=${weekinfo['prev_weeknumber']}&year=${weekinfo['prev_year']}" title="Previous Week (${weekinfo['prev_weeknumber']})" onclick="arrows_page();">
                       <img src="${icons['prev']}" width="16" height="18" Alt="Previous"/>
                   </a>
               </td>
@@ -69,7 +69,7 @@
               %endif
               </td>
               <td style="vertical-align: middle; text-align: left">
-                    <a href="pullist?week=${weekinfo['next_weeknumber']}&year=${weekinfo['next_year']}&current=${weekinfo['weeknumber']}-${weekinfo['year']}" title="Next Week (${weekinfo['next_weeknumber']})" onclick="arrows_page();">
+                    <a href="pullist?week=${weekinfo['next_weeknumber']}&year=${weekinfo['next_year']}" title="Next Week (${weekinfo['next_weeknumber']})" onclick="arrows_page();">
                       <img src="${icons['next']}" width="16" height="18" Alt="Next"/>
                   </a>
               </td>

--- a/mylar/helpers.py
+++ b/mylar/helpers.py
@@ -2696,115 +2696,68 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
     #torrent_info['snatch_status'] = snatch_status
     return torrent_info
 
-def weekly_info(week=None, year=None, current=None):
-    #find the current week and save it as a reference point.
-    todaydate = datetime.datetime.today()
-    if todaydate.year == 2025:
-        current_weeknumber = todaydate.isocalendar()[1]
-    else:
-        current_weeknumber = todaydate.strftime("%U")
-    if current is not None:
-        c_weeknumber = int(current[:current.find('-')])
-        c_weekyear = int(current[current.find('-')+1:])
-    else:
-        c_weeknumber = week
-        c_weekyear = year
+def weekly_info(week=None, year=None):
+    """Generates data for Mylar's week numbering calendar.  This is aligned with TalkHard's view of weeks
+    where the nth week is defined by the number of Wednesdays in that year up to that point.  Mylar bounds
+    the week between Sunday and Saturday inclusive.  There are either 52 or 53 weeks in a year.
+
+    Args:
+        week: The week number.  If not included, will default to today's date.
+        year: The year number.
+
+    Returns:
+        A dict of current and neighbouring week data.
+    """
+    # TODO: End up having to do this twice to keep the current_weeknumber which is used for various checks.  This should all be split into smaller units.
+    # Calculate the current "week" based on the Wednesday
+    today_date: date = datetime.date.today()
+    shift_to_weds: int = 3 - ((today_date.weekday() + 1) % 7)
+    release_day: date = today_date + datetime.timedelta(days=shift_to_weds)
+    # Caclulates based on where the start of year falls (i.e. is it week 1 this year, or week 53 previous year)
+    first_jan = release_day.replace(day=1, month=1)
+    current_weeknumber =  (1 if ((first_jan.weekday() + 1) % 7) <= 3 else 0) + (release_day.timetuple().tm_yday // 7)
+    weeknumber = current_weeknumber
+    current_year = release_day.year
+    start_week: date = release_day + datetime.timedelta(days=-3)
+    end_week: date = release_day + datetime.timedelta(days=3)
+    leap_week = (first_jan.weekday() == 2) or (first_jan.weekday() == 1 and ((current_year % 4 == 0 and current_year % 100 != 0) or (current_year % 400 == 0)))
+    
 
     if week:
         weeknumber = int(week)
-        year = int(year)
-    else:
-        #find the given week number for the current day
-        weeknumber = int(current_weeknumber)
-        year = int(todaydate.strftime("%Y"))
+        current_year = int(year)
+        first_jan = datetime.date(current_year,1,1)
+        distance_to_weds = 3 - ((first_jan.weekday() + 1) % 7)
+        first_weds = datetime.date(current_year, 1, 8 + distance_to_weds) if distance_to_weds < 0 else datetime.date(current_year, 1, 1 + distance_to_weds)
+        release_day = first_weds + datetime.timedelta(weeks=weeknumber-1)
+        start_week: date = release_day + datetime.timedelta(days=-3)
+        end_week: date = release_day + datetime.timedelta(days=3)
+        leap_week = (first_jan.weekday() == 2) or (first_jan.weekday() == 1 and ((current_year % 4 == 0 and current_year % 100 != 0) or (current_year % 400 == 0)))
 
-    #monkey patch for 2018/2019 - week 52/week 0
-    if all([weeknumber == 52, c_weeknumber == 51, c_weekyear == 2018]):
-        weeknumber = 0
-        year = 2019
-    elif all([weeknumber == 52, c_weeknumber == 0, c_weekyear == 2019]):
-        weeknumber = 51
-        year = 2018
+        if weeknumber > 52 and not leap_week:
+            logger.warning(f'Tried to fetch week 53 for year {current_year} without leap week.  Correcting to week 1 {current_year+1}.')
+            weeknumber = 1
+            current_year += 1
 
-    #monkey patch for 2019/2020 - week 52/week 0
-    if all([weeknumber == 52, c_weeknumber == 51, c_weekyear == 2019]) or all([weeknumber == '52', year == '2019']):
-        weeknumber = 0
-        year = 2020
-    elif all([weeknumber == 52, c_weeknumber == 0, c_weekyear == 2020]):
-        weeknumber = 51
-        year = 2019
+    # Defaults
+    prev_weeknumber= weeknumber - 1
+    prev_year = current_year
+    next_weeknumber = weeknumber + 1
+    next_year = current_year
 
-    #monkey patch for 2020/2021 - week 52/week 0
-    if all([int(weeknumber) == 0, int(year) == 2021]) or all([int(weeknumber) == 52, int(year) == 2020]):
-        weeknumber = 52
-        year = 2020
+    if prev_weeknumber == 0:
+        prev_year = current_year - 1
+        prev_first_jan = datetime.date(prev_year, 1, 1)
+        prev_leap_week = (prev_first_jan.weekday() == 2) or (prev_first_jan.weekday() == 1 and ((prev_year % 4 == 0 and prev_year % 100 != 0) or (prev_year % 400 == 0)))
+        prev_weeknumber = 53 if prev_leap_week else 52
+    elif (next_weeknumber == 53 and not leap_week) or (next_weeknumber > 53):
+        next_weeknumber = 1
+        next_year = current_year + 1
 
-    #monkey patch for 2021/2022 - week 52/week 0
-    if all([int(weeknumber) == 0, int(year) == 2022]) or all([int(weeknumber) == 52, int(year) == 2021]):
-        weeknumber = 52
-        year = 2021
-
-    #monkey patch for 2024/2025 - week 52/week 0
-    if all([weeknumber == 52, c_weeknumber == 51, c_weekyear == 2024]) or all([weeknumber == '52', year == '2024']):
-        weeknumber = 1
-        year = 2025
-    elif any([weeknumber == 52, weeknumber == 0]) and all([c_weeknumber == 1, c_weekyear == 2025]):
-        weeknumber = 51
-        year = 2024
-
-    startofyear = date(year,1,1)
-    week0 = startofyear - timedelta(days=startofyear.isoweekday())
-    stweek = datetime.datetime.strptime(week0.strftime('%Y-%m-%d'), '%Y-%m-%d')
-    if year == 2025:
-        startweek = stweek + timedelta(weeks = weeknumber -1)
-    else:
-        startweek = stweek + timedelta(weeks = weeknumber)
-
-    midweek = startweek + timedelta(days = 3)
-    endweek = startweek + timedelta(days = 6)
-
-    if all([weeknumber == 1, year == 2021]):
-        # make sure the arrow going back will hit the correct week in the previous year.
-        prev_week = 52
-        prev_year = 2020
-    elif all([weeknumber == 0, year == 2022]):
-        # make sure the arrow going back will hit the correct week in the previous year.
-        prev_week = 52
-        prev_year = 2021
-    elif all([weeknumber == 0, year == 2025]):
-        # make sure the arrow going back will hit the correct week in the previous year.
-        prev_week = 51
-        prev_year = 2024
-    else:
-        prev_week = int(weeknumber) - 1
-        prev_year = year
-        if prev_week < 0:
-            prev_week = 52
-            prev_year = int(year) - 1
-
-    next_week = int(weeknumber) + 1
-    next_year = year
-    if next_week > 52:
-        next_year = int(year) + 1
-        if all([weeknumber == 52, year == 2020]):
-            # make sure the next arrow will hit the correct week in the following year.
-            next_week = '1'
-        elif all([weeknumber == 52, year == 2021]):
-            # make sure the next arrow will hit the correct week in the following year.
-            next_week = '1'
-        elif all([weeknumber == 51, year == 2024]):
-            # make sure the next arrow will hit the correct week in the following year.
-            next_week = '1'
-        else:
-            next_week = datetime.date(int(next_year),1,1).strftime("%U")
 
     date_fmt = "%B %d, %Y"
-    try:
-        con_startweek = "" + startweek.strftime(date_fmt)
-        con_endweek = "" + endweek.strftime(date_fmt)
-    except:
-        con_startweek = "" + startweek.strftime(date_fmt)
-        con_endweek = "" + endweek.strftime(date_fmt)
+    con_startweek = start_week.strftime(date_fmt)
+    con_endweek = end_week.strftime(date_fmt)
 
     if mylar.CONFIG.WEEKFOLDER_LOC is not None:
         weekdst = mylar.CONFIG.WEEKFOLDER_LOC
@@ -2819,14 +2772,14 @@ def weekly_info(week=None, year=None, current=None):
 
     weekinfo = {'weeknumber':         weeknumber,
                 'startweek':          con_startweek,
-                'midweek':            midweek.strftime('%Y-%m-%d'),
+                'midweek':            release_day.strftime('%Y-%m-%d'),
                 'endweek':            con_endweek,
-                'year':               year,
-                'prev_weeknumber':    prev_week,
+                'year':               current_year,
+                'prev_weeknumber':    prev_weeknumber,
                 'prev_year':          prev_year,
-                'next_weeknumber':    next_week,
+                'next_weeknumber':    next_weeknumber,
                 'next_year':          next_year,
-                'current_weeknumber': current_weeknumber,
+                'current_weeknumber': str(current_weeknumber).zfill(2),
                 'last_update':        weekly_last}
 
     if weekdst is not None:

--- a/mylar/locg.py
+++ b/mylar/locg.py
@@ -24,6 +24,7 @@ from mylar.helpers import ignored_publisher_check
 def locg(pulldate=None,weeknumber=None,year=None):
 
         todaydate = datetime.datetime.today().replace(second=0,microsecond=0)
+        # TODO: pulldate appears to be another legacy code branch, but if needed should be burned and replaced with the common weekly_info call
         if pulldate:
             logger.info('pulldate is : ' + str(pulldate))
             if pulldate is None or pulldate == '00000000':
@@ -38,7 +39,7 @@ def locg(pulldate=None,weeknumber=None,year=None):
                     weeknumber = weeknumber_new
 
         else:
-            if str(weeknumber).isdigit() and int(weeknumber) <= 52:
+            if str(weeknumber).isdigit() and int(weeknumber) <= 53:
                 #already requesting week #
                 weeknumber = weeknumber
             else:

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -2963,7 +2963,6 @@ class WebInterface(object):
         week = None
         year = None
         generateonly = False
-        current = None
         for k,v in list(args.items()):
             if k == 'week':
                 week = v
@@ -2971,8 +2970,6 @@ class WebInterface(object):
                 year = v
             elif k == 'generateonly':
                 generateonly = v
-            elif k == 'current':
-                current = v
 
         myDB = db.DBConnection()
         autowant = []
@@ -2987,7 +2984,7 @@ class WebInterface(object):
                                      "DisplayComicName": aw['DisplayComicName']})
         weeklyresults = []
         wantedcount = 0
-        weekinfo = helpers.weekly_info(week, year, current)
+        weekinfo = helpers.weekly_info(week, year)
         popit = myDB.select("SELECT * FROM sqlite_master WHERE name='weekly' and type='table'")
         if popit:
             w_results = myDB.select("SELECT * from weekly WHERE weeknumber=? AND year=?", [int(weekinfo['weeknumber']),weekinfo['year']])

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -173,9 +173,9 @@ def test_LoadAlternateSearchNames(test, result):
 
 filesafe_tests = [
     ("", ""),
-    ("This is a — comic", "This is a  -  comic"),
-    ("This is a: comic", "This is a comic"),
-    ("This is a\ comic", "This is a comic"),
+    (r"This is a — comic", "This is a  -  comic"),
+    (r"This is a: comic", "This is a comic"),
+    (r"This is a\ comic", "This is a comic"),
 ]
 
 
@@ -257,14 +257,26 @@ def test_arcformat(monkeypatch):
 
 
 weekly_info_tests = [
-    (('12', '2025', '42'), {'endweek': 'March 22, 2025', 'last_update': 'None', 'midweek': '2025-03-19', 'next_weeknumber': 13,
+    (('12', '2025'), {'endweek': 'March 22, 2025', 'last_update': 'None', 'midweek': '2025-03-19', 'next_weeknumber': 13,
                             'next_year': 2025, 'prev_weeknumber': 11, 'prev_year': 2025, 'startweek': 'March 16, 2025',
                             'weeknumber': 12, 'year': 2025}),
-    (('52', '2024', '52'), {'endweek': 'January 04, 2025', 'last_update': 'None', 'midweek': '2025-01-01', 'next_weeknumber': '00',
-                            'next_year': 2025, 'prev_weeknumber': 51, 'prev_year': 2024, 'startweek': 'December 29, 2024',
-                            'weeknumber': 52, 'year': 2024}),
-    (('01', '2019', '11'), {'endweek': 'January 12, 2019', 'last_update': 'None', 'midweek': '2019-01-09', 'next_weeknumber': 2,
-                            'next_year': 2019, 'prev_weeknumber': 0, 'prev_year': 2019, 'startweek': 'January 06, 2019',
+    (('52', '2025'), {'endweek': 'December 27, 2025', 'last_update': 'None', 'midweek': '2025-12-24', 'next_weeknumber': 53,
+                            'next_year': 2025, 'prev_weeknumber': 51, 'prev_year': 2025, 'startweek': 'December 21, 2025',
+                            'weeknumber': 52, 'year': 2025}),
+    (('53', '2025'), {'endweek': 'January 03, 2026', 'last_update': 'None', 'midweek': '2025-12-31', 'next_weeknumber': 1,
+                            'next_year': 2026, 'prev_weeknumber': 52, 'prev_year': 2025, 'startweek': 'December 28, 2025',
+                            'weeknumber': 53, 'year': 2025}),
+    (('01', '2026'), {'endweek': 'January 10, 2026', 'last_update': 'None', 'midweek': '2026-01-07', 'next_weeknumber': 2,
+                            'next_year': 2026, 'prev_weeknumber': 53, 'prev_year': 2025, 'startweek': 'January 04, 2026',
+                            'weeknumber': 1, 'year': 2026}),
+    (('52', '2026'), {'endweek': 'January 02, 2027', 'last_update': 'None', 'midweek': '2026-12-30', 'next_weeknumber': 1,
+                            'next_year': 2027, 'prev_weeknumber': 51, 'prev_year': 2026, 'startweek': 'December 27, 2026',
+                            'weeknumber': 52, 'year': 2026}),
+    (('53', '2026'), {'endweek': 'January 09, 2027', 'last_update': 'None', 'midweek': '2027-01-06', 'next_weeknumber': 2,
+                            'next_year': 2027, 'prev_weeknumber': 52, 'prev_year': 2026, 'startweek': 'January 03, 2027',
+                            'weeknumber': 1, 'year': 2027}),
+    (('01', '2019'), {'endweek': 'January 05, 2019', 'last_update': 'None', 'midweek': '2019-01-02', 'next_weeknumber': 2,
+                            'next_year': 2019, 'prev_weeknumber': 52, 'prev_year': 2018, 'startweek': 'December 30, 2018',
                             'weeknumber': 1, 'year': 2019}),
 ]
 
@@ -277,7 +289,8 @@ def test_weekly_info_format0(patch_datetime, monkeypatch, input, result):
     monkeypatch.setattr(mylar.CONFIG, "DESTINATION_DIR", os.getcwd(), raising=False)
     monkeypatch.setattr(mylar.CONFIG, "WEEKFOLDER_FORMAT", 0, raising=False)
 
-    assert helpers.weekly_info(*input) == {'current_weeknumber': '51',
+    # current_weeknumber is fixed by the datetime patch
+    assert helpers.weekly_info(*input) == {'current_weeknumber': '52',
                                            'endweek': result['endweek'],
                                            'last_update': result['last_update'],
                                            'midweek': result['midweek'],
@@ -299,7 +312,7 @@ def test_weekly_info_format1(patch_datetime, monkeypatch, input, result):
     monkeypatch.setattr(mylar.CONFIG, "DESTINATION_DIR", os.getcwd(), raising=False)
     monkeypatch.setattr(mylar.CONFIG, "WEEKFOLDER_FORMAT", 1, raising=False)
 
-    assert helpers.weekly_info(*input) == {'current_weeknumber': '51',
+    assert helpers.weekly_info(*input) == {'current_weeknumber': '52',
                                            'endweek': result['endweek'],
                                            'last_update': result['last_update'],
                                            'midweek': result['midweek'],


### PR DESCRIPTION
Recalculates the week numbering based on the Wednesday driven release calendar for TalkHard, so should stay perpetually in line (with a leap week calculation).  No more week 0, so a year is either 52 or 53 weeks.

This is another one of those "do a load of unrelated stuff and throw it in a dict" type functions that really could be better broken down into smaller units and then called more clearly where those additional bits of information are used (e.g. current_weeknumber really should just be the function called with a current date).  Not a priority to refactor right now, but it explains the need to duplicate some work to do the calcs for current and specific week.