### PR TITLE
fix: check for addition of duplicates to mass-add queue

### DIFF
--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -1834,6 +1834,14 @@ def importer_thread(serieslist):
     if type(serieslist) != list:
         serieslist  = [(serieslist)]
 
+    # A very basic preclean check to avoid duplication.  In an ideal world we'd be more disciplined about adding in the first place, and
+    # also perform this check properly by ID, but this will solve some problems caused upstream
+    filtered_list = [entry for entry in serieslist if entry not in mylar.ADD_LIST.queue]
+    filtered_count = len(serieslist) - len(filtered_list)
+    if filtered_count > 0:
+        logger.info(f'[MASS-ADD] Ignoring request to add {filtered_count} series already in queue')
+        serieslist = filtered_list
+
     threaded_call = True
 
     list(map(mylar.ADD_LIST.put, serieslist))


### PR DESCRIPTION
Testing with Morsok.  Byproduct of new TH backend is that better matching has thrown up an issue where new volumes were getting recursively added to the mass-add queue until they were added to the DB proper.  While this should be cleaned up upstream (the check on every volume refresh has to be slowing things down unnecessarily), this is a sensible guard to have in place regardless.  Could argue for a better queue object (some form of orderedset instead of a deque behind it), but this will do for mylar.