### PR TITLE
fix: avoid trying to use $type for folder deduplication on print volumes

### DIFF
--- a/mylar/filers.py
+++ b/mylar/filers.py
@@ -345,7 +345,7 @@ class FileHandlers(object):
                         volumeyear = True
                     else:
                         volumeyear = False
-                    if '$Type' not in tmp_ff and booktype != ck['Type']:
+                    if '$Type' not in tmp_ff and booktype != ck['Type'] and booktype is not None and booktype != 'Print':
                         logger.fdebug('[SERIES_FOLDER_COLLISION_DETECTION] Trying to rename using BookType declaration.')
                         new_format = os.path.join(tmp_ff_head, '%s [%s]' % (tmp_ff, '$Type'))
                     elif '$Volume' not in tmp_ff:


### PR DESCRIPTION
Because a later part of the process ignores the $Type placeholder if it's a Print volume, it can't be used for de-duplication for those volumes.