### PR TITLE
Fix: file matcher fails on single-volume series with numeric/year-in-…

### DIFF
--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -44,7 +44,7 @@ if 'windows' not in platform.system().lower():
 
 class FileChecker(object):
 
-    def __init__(self, dir=None, watchcomic=None, Publisher=None, AlternateSearch=None, manual=None, sarc=None, justparse=None, file=None, pp_mode=False):
+    def __init__(self, dir=None, watchcomic=None, Publisher=None, AlternateSearch=None, manual=None, sarc=None, justparse=None, file=None, pp_mode=False, comic_type=None, single_issue_series=False, single_issue_number=None):
         #dir = full path to the series Comic Location (manual pp will just be psssing the already parsed filename)
         if dir:
             self.dir = dir
@@ -110,6 +110,19 @@ class FileChecker(object):
         self.dynamic_handlers = ['/','-',':',';','\'','"',',','&','?','!','+','*','(',')','\\u2014','\\u2013','\\u2019']
         self.dynamic_replacements = ['and','the']
         self.rippers = ['-empire','-empire-hd','minutemen-','-dcp','Glorith-HD']
+
+        # Type-bypass: when a One-Shot/GN/TPB/HC series has Mylar Total=1
+        # and the folder has exactly one non-marker file, parseit forces
+        # issue_number to the issue # Mylar got from CV (not always '1' —
+        # CV sometimes assigns random numbers like 220 to a single-issue
+        # series). Fixes the numeric-title-in-filename trap (e.g. "7174
+        # Annual (2022).cbr" being parsed as issue #7174). Marker files
+        # (primer/ashcan/preview/sneak peek not in the series name) stay
+        # orphaned in the same folder; only the main file gets matched.
+        # See: scripts/mylar_type_bypass_patch.py for re-apply on update.
+        self.comic_type = comic_type
+        self.single_issue_series = bool(single_issue_series)
+        self.single_issue_number = single_issue_number
 
         #pre-generate the AS_Alternates now
         AS_Alternates = self.altcheck()
@@ -1319,6 +1332,68 @@ class FileChecker(object):
                     issue_number = isn
                 series_name = re.sub('special', '', series_name, flags=re.I).strip()
                 series_name_decoded = re.sub('special', '', series_name_decoded, flags=re.I).strip()
+
+        # ---- Type-bypass v1.1 for single-volume publications -------------
+        # Fixes Mylar's filename parser when the title contains digits that
+        # aren't the issue number — e.g. "7174 Annual (2022).cbr" (parser
+        # grabs 7174 as issue#), "Cyberpunk 2077 (2021)" (grabs 2077),
+        # "1001 Reasons (2024)" (grabs 1001). For single-volume Types
+        # (One-Shot/GN/TPB/HC) we skip the parser's number extraction and
+        # use Mylar's actual CV-assigned issue # (could be 1, 0, 220, etc.).
+        try:
+            _ct = getattr(self, 'comic_type', None)
+            _sis = getattr(self, 'single_issue_series', False)
+            _sin = getattr(self, 'single_issue_number', None)
+            if (_ct in ('One-Shot', 'GN', 'Graphic Novel', 'TPB', 'HC')
+                    and _sis and _sin is not None):
+                _folder = self.dir if self.dir and os.path.isdir(self.dir) else None
+                if _folder:
+                    _ft = ('.cbr', '.cbz', '.cb7', '.pdf')
+                    _all = [_f for _f in os.listdir(_folder)
+                            if _f.lower().endswith(_ft)]
+                    _markers = ('primer', 'ashcan', 'preview', 'sneak peek')
+                    _watch_low = (self.watchcomic or '').lower()
+                    def _is_marker(_fn):
+                        _fl = _fn.lower()
+                        return any(_m in _fl and _m not in _watch_low
+                                   for _m in _markers)
+                    _non_marker = [_f for _f in _all if not _is_marker(_f)]
+                    if len(_non_marker) == 1 and filename == _non_marker[0]:
+                        if str(issue_number) != str(_sin):
+                            logger.fdebug(
+                                '[TYPE-BYPASS] Type=%s + Mylar Total=1 + '
+                                'single non-marker file (%d of %d in folder). '
+                                'Overriding parsed issue_number %r -> %r '
+                                '(using Mylar/CV-assigned single issue#)' %
+                                (_ct, 1, len(_all), issue_number, _sin)
+                            )
+                        issue_number = _sin
+                        if booktype == 'issue':
+                            booktype = 'GN' if _ct == 'Graphic Novel' else _ct
+                        # v1.2 extension: also override series_name to match
+                        # the watchcomic. Our bypass already established the
+                        # file belongs to this series (we're in its folder,
+                        # it's the only non-marker file, single-volume Type,
+                        # Total=1). The parser may have eaten a trailing
+                        # year out of the title (e.g. "Hellboy Winter Special
+                        # 2018" → "Hellboy Winter Special" because filename
+                        # also has "(2018)" year-paren), which causes matchIT
+                        # to reject. Bypassing series_name = watchcomic skips
+                        # that mismatch and lets the match succeed.
+                        if self.watchcomic and series_name != self.watchcomic:
+                            logger.fdebug(
+                                '[TYPE-BYPASS] series_name override: %r -> %r '
+                                '(watchcomic; parser may have eaten trailing year)' %
+                                (series_name, self.watchcomic)
+                            )
+                            series_name = self.watchcomic
+                            try:
+                                series_name_decoded = self.watchcomic
+                            except Exception:
+                                pass
+        except Exception as _e:
+            logger.fdebug('[TYPE-BYPASS] check failed: %s' % _e)
+        # ------------------------------------------------------------------
 
         if (any([issue_number is None, series_name is None]) and booktype == 'issue'):
             bythepass = False

--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -1340,6 +1340,19 @@ class FileChecker(object):
         # "1001 Reasons (2024)" (grabs 1001). For single-volume Types
         # (One-Shot/GN/TPB/HC) we skip the parser's number extraction and
         # use Mylar's actual CV-assigned issue # (could be 1, 0, 220, etc.).
+        #
+        # Bypass fires when ALL of:
+        #   - comic_type is single-volume
+        #   - single_issue_series is True (Mylar Total == 1)
+        #   - single_issue_number was passed (caller looked it up in mylar.db)
+        #   - folder has exactly ONE non-marker comic file
+        #   - this parse pass is on that non-marker file
+        # A "marker" file has primer/ashcan/preview/sneak peek in its name
+        # AND that word is NOT in the series name (so series named "Primer"
+        # or "The [TR]Ashcan" aren't treated as markers). Marker files in
+        # the same folder stay orphaned (correct — Mylar has no issue # for
+        # them; CV doesn't track most ashcans/primers as separate issues).
+        # NOT included as markers: 'annual', 'holiday special' (too unreliable).
         try:
             _ct = getattr(self, 'comic_type', None)
             _sis = getattr(self, 'single_issue_series', False)
@@ -1370,27 +1383,101 @@ class FileChecker(object):
                         issue_number = _sin
                         if booktype == 'issue':
                             booktype = 'GN' if _ct == 'Graphic Novel' else _ct
-                        # v1.2 extension: also override series_name to match
-                        # the watchcomic. Our bypass already established the
-                        # file belongs to this series (we're in its folder,
-                        # it's the only non-marker file, single-volume Type,
-                        # Total=1). The parser may have eaten a trailing
-                        # year out of the title (e.g. "Hellboy Winter Special
-                        # 2018" → "Hellboy Winter Special" because filename
-                        # also has "(2018)" year-paren), which causes matchIT
-                        # to reject. Bypassing series_name = watchcomic skips
-                        # that mismatch and lets the match succeed.
+                        # v1.7 series_name override: filename significant
+                        # tokens must EQUAL the ordered tokens of EITHER
+                        # watchcomic OR any AltSearch entry (after paren
+                        # strip + issue#/year exclusion). Same words,
+                        # same sequence, no extras, no missing. AltSearch
+                        # is how the user declares "this alternate name
+                        # is also valid for this series" -- the bypass
+                        # respects that. Anything else REFUSE.
+                        # Stops are only true articles/prepositions.
                         if self.watchcomic and series_name != self.watchcomic:
-                            logger.fdebug(
-                                '[TYPE-BYPASS] series_name override: %r -> %r '
-                                '(watchcomic; parser may have eaten trailing year)' %
-                                (series_name, self.watchcomic)
-                            )
-                            series_name = self.watchcomic
-                            try:
-                                series_name_decoded = self.watchcomic
-                            except Exception:
-                                pass
+                            _stop = {
+                                'the', 'and', 'a', 'an', 'of', 'in', 'to',
+                                'for', 'on', 'at', 'by', 'with', 'or',
+                            }
+                            # Drop the override issue# from BOTH sides
+                            # so legit "Series 001 (Year)" filenames
+                            # don't trip on the extra issue tag. KEEP
+                            # year as an anchor -- "Avengers 1999" and
+                            # "Hellboy Winter Special 2018" have year
+                            # baked into the CV title and that's
+                            # load-bearing for distinguishing files.
+                            _drop_norms = set()
+                            for _d in (_sin, issue_number):
+                                if _d is None or _d == '':
+                                    continue
+                                _ds = str(_d)
+                                _drop_norms.add(_ds)
+                                if _ds.isdigit():
+                                    _drop_norms.add(_ds.lstrip('0') or '0')
+                            def _toks_ordered(_s):
+                                _s = re.sub(r'\([^)]*\)', '', _s or '')
+                                _s = _s.lower()
+                                _out = []
+                                for _t in re.findall(r"[a-z0-9'\-]+", _s):
+                                    if _t in _stop:
+                                        continue
+                                    if not (_t.isdigit() or len(_t) >= 2):
+                                        continue
+                                    _tn = _t.lstrip('0') if _t.isdigit() else _t
+                                    if _t in _drop_norms or _tn in _drop_norms:
+                                        continue
+                                    _out.append(_t)
+                                return _out
+                            _wc_list = _toks_ordered(self.watchcomic)
+                            _fn_base = os.path.splitext(filename)[0]
+                            _fn_list = _toks_ordered(_fn_base)
+                            # Build the list of acceptable target names:
+                            # watchcomic + each AltSearch entry. AltSearch
+                            # is stored as "Name1!!ID1##Name2!!ID2..." or
+                            # plain. Strip !!ID suffixes and split on ##.
+                            _candidates = [('watchcomic', self.watchcomic,
+                                            _wc_list)]
+                            _alt_raw = getattr(self, 'AlternateSearch', None)
+                            if _alt_raw and _alt_raw.lower() != 'none':
+                                for _entry in _alt_raw.split('##'):
+                                    _name = _entry.split('!!')[0].strip()
+                                    if not _name:
+                                        continue
+                                    _candidates.append(
+                                        ('altsearch', _name,
+                                         _toks_ordered(_name))
+                                    )
+                            _matched = None
+                            for _src, _name, _toks in _candidates:
+                                if _fn_list and _fn_list == _toks:
+                                    _matched = (_src, _name, _toks)
+                                    break
+                            if _matched:
+                                logger.fdebug(
+                                    '[TYPE-BYPASS] series_name override: %r -> '
+                                    '%r via %s (filename ordered tokens %r '
+                                    '== %s ordered tokens %r)' %
+                                    (series_name, _matched[1], _matched[0],
+                                     _fn_list, _matched[0], _matched[2])
+                                )
+                                series_name = _matched[1]
+                                try:
+                                    series_name_decoded = _matched[1]
+                                except Exception:
+                                    pass
+                            else:
+                                _extras = set(_fn_list) - set(_wc_list)
+                                _missing = set(_wc_list) - set(_fn_list)
+                                logger.fdebug(
+                                    '[TYPE-BYPASS] series_name override '
+                                    'REFUSED: filename %r tokens=%r did not '
+                                    'match watchcomic %r tokens=%r nor any '
+                                    'AltSearch entry %r. (extras vs wc=%r, '
+                                    'missing vs wc=%r). Add an AltSearch '
+                                    'whose tokens match the filename.' %
+                                    (filename, _fn_list, self.watchcomic,
+                                     _wc_list,
+                                     [c[1] for c in _candidates[1:]],
+                                     _extras, _missing)
+                                )
         except Exception as _e:
             logger.fdebug('[TYPE-BYPASS] check failed: %s' % _e)
         # ------------------------------------------------------------------

--- a/mylar/updater.py
+++ b/mylar/updater.py
@@ -1152,9 +1152,19 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
                 altnames += ascan['ReleaseComicName'] + '!!' + ascan['ReleaseComicID'] + '##'
         altnames = altnames[:-2]
     logger.info(module + ' Now checking files for ' + rescan['ComicName'] + ' (' + str(rescan['ComicYear']) + ') in ' + rescan['ComicLocation'])
+
+    # v1.1 Type-bypass: look up Mylar's single issue # for single-volume
+    # series so the FileChecker bypass uses the actual CV-assigned number
+    # (could be 1, 0, 220 — CV varies for single-volume series).
+    _single_issue_num = None
+    if rescan['Total'] == 1:
+        _siq = myDB.select("SELECT Issue_Number FROM issues WHERE ComicID=? LIMIT 1", [ComicID])
+        if _siq:
+            _single_issue_num = _siq[0]['Issue_Number']
+
     fca = []
     if archive is None:
-        tval = filechecker.FileChecker(dir=rescan['ComicLocation'], watchcomic=rescan['ComicName'], Publisher=rescan['ComicPublisher'], AlternateSearch=altnames)
+        tval = filechecker.FileChecker(dir=rescan['ComicLocation'], watchcomic=rescan['ComicName'], Publisher=rescan['ComicPublisher'], AlternateSearch=altnames, comic_type=rescan['Type'], single_issue_series=(rescan['Total'] == 1), single_issue_number=_single_issue_num)
         tmpval = tval.listFiles()
         #tmpval = filechecker.listFiles(dir=rescan['ComicLocation'], watchcomic=rescan['ComicName'], Publisher=rescan['ComicPublisher'], AlternateSearch=altnames)
         comiccnt = int(tmpval['comiccount'])
@@ -1172,7 +1182,7 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
                 logger.fdebug(module + 'dir: ' + rescan['ComicLocation'])
                 logger.fdebug(module + 'os.path.basename: ' + os.path.basename(rescan['ComicLocation']))
                 logger.info(module + ' Now checking files for ' + rescan['ComicName'] + ' (' + str(rescan['ComicYear']) + ') in :' + secondary_folders)
-                mvals = filechecker.FileChecker(dir=secondary_folders, watchcomic=rescan['ComicName'], Publisher=rescan['ComicPublisher'], AlternateSearch=altnames)
+                mvals = filechecker.FileChecker(dir=secondary_folders, watchcomic=rescan['ComicName'], Publisher=rescan['ComicPublisher'], AlternateSearch=altnames, comic_type=rescan['Type'], single_issue_series=(rescan['Total'] == 1), single_issue_number=_single_issue_num)
                 tmpv = mvals.listFiles()
                 #tmpv = filechecker.listFiles(dir=secondary_dir, watchcomic=rescan['ComicName'], Publisher=rescan['ComicPublisher'], AlternateSearch=altnames)
                 logger.fdebug(module + 'tmpv filecount: ' + str(tmpv['comiccount']))
@@ -1182,7 +1192,7 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
             pass
     else:
 #        files_arc = filechecker.listFiles(dir=archive, watchcomic=rescan['ComicName'], Publisher=rescan['ComicPublisher'], AlternateSearch=rescan['AlternateSearch'])
-        arcval = filechecker.FileChecker(dir=archive, watchcomic=rescan['ComicName'], Publisher=rescan['ComicPublisher'], AlternateSearch=rescan['AlternateSearch'])
+        arcval = filechecker.FileChecker(dir=archive, watchcomic=rescan['ComicName'], Publisher=rescan['ComicPublisher'], AlternateSearch=rescan['AlternateSearch'], comic_type=rescan['Type'], single_issue_series=(rescan['Total'] == 1), single_issue_number=_single_issue_num)
         files_arc = arcval.listFiles()
         fca.append(files_arc)
         comiccnt = int(files_arc['comiccount'])


### PR DESCRIPTION
# Fix: file matcher fails on single-volume series with numeric/year-in-title filenames

## Problem

Mylar's `FileChecker.parseit()` extracts issue numbers from filenames using
regex against the filename string. For single-volume series (Type=One-Shot,
GN, Graphic Novel, TPB, HC) where the title contains digits that aren't
the issue number, the parser misidentifies the issue and `matchIT` rejects
the file. Affected files end up `Status='Archived'` permanently with no
diagnostic surfaced in the UI.

Two failure modes covered:

### Mode 1 — issue# extraction trap

Title contains digits that aren't the issue number:
- `7174 Annual (2022) (Digital) (Zone-Empire).cbr` → parser thinks issue = 7174
- `Cyberpunk 2077 (2021).cbr` → parser thinks issue = 2077
- `1001 Reasons to Hate Applebee's (2024).cbr` → parser thinks issue = 1001

Mylar looks for issue 7174 / 2077 / 1001 in `issues` table, doesn't find,
rejects the file. Series Type field in `mylar.db.comics` (One-Shot, GN, etc.)
is never plumbed into FileChecker, so it has no way to recognize "this is
the single issue regardless of the digits in the filename."

### Mode 2 — year-in-title eaten as year

Title ENDS with a year that matches the filename's year-paren:
- `Hellboy Winter Special 2018 (2018) (digital) (Son of Ultron II-Empire).cbr`
- `Zombie Tramp Halloween Special 2016 (2016) (Digital) (TheArchivist-Empire).cbr`

Parser strips the title's `2018` thinking it's the year (the in-paren `(2018)`
is already the year), leaving `series_name='Hellboy Winter Special'`. The
watchcomic is `'Hellboy Winter Special 2018'`. Mismatch → `matchIT` rejects.

## Reproduction

1. Create a series in Mylar with Type=One-Shot, Total=1
2. Drop a file in the comic folder named `7174 Annual (2022).cbr` (or any
   variant with a numeric token in the title)
3. Trigger recheckFiles
4. Observe: file remains Archived; issue#1 in DB still Status=Archived
5. Check `mylar.log`: `parse_status: failure`, `issue_number: 7174` (wrong)

Pre-patch behavior verified 2026-05-15 with `changeStatus` API forcing
Status=Downloaded; subsequent recheckFiles reverts back to Archived,
confirming parser-side failure (not a status-tracking issue).

## Root cause

`FileChecker.__init__` doesn't accept the comic's Type field. The matcher
operates blind to whether the series is single-volume or multi-issue.
Even when Type is explicitly set in the Mylar UI, that information is
never plumbed to the matcher.

## Fix

Plumb three new params through `FileChecker`:
- `comic_type` — from `mylar.db.comics.Type`
- `single_issue_series` — `True` when Total == 1
- `single_issue_number` — actual CV-assigned issue # (could be `1`, `0`,
  `220`, etc. — CV is inconsistent for single-volume series)

In `parseit()`, just before the existing failure check, add a guarded
bypass block:

```python
SINGLE_VOLUME_TYPES = ('One-Shot', 'GN', 'Graphic Novel', 'TPB', 'HC')
if (comic_type in SINGLE_VOLUME_TYPES
        and single_issue_series
        and single_issue_number is not None
        and folder has exactly 1 non-marker file
        and this parse pass is on that file):
    # Skip the parser's number extraction — use Mylar's actual issue#
    issue_number = single_issue_number
    booktype = comic_type
    series_name = self.watchcomic  # ← bypasses year-eaten-as-year too
```

A "marker" file has primer/ashcan/preview/sneak peek in name AND that
word is NOT in the series name. Handles the case where someone places
an orphaned ashcan/primer next to the main one-shot — only the main file
is matched; the marker file stays unmatched (which is correct: CV
typically doesn't track ashcans as separate issues).

Caller updates (3 sites in `updater.py forceRescan`): lookup Mylar's
single issue # when `Total==1`, pass through to FileChecker.

## Files changed

- `mylar/filechecker.py` — `__init__` signature (+3 params), storage,
  bypass block in `parseit()`
- `mylar/updater.py` — single-issue lookup + 3 FileChecker call sites

## Testing (2026-05-15)

End-to-end recheckFiles tests against real collection, 7/7 passed:

| ComicID | Series | Test | Result |
|---|---|---|---|
| 141807 | 7174 Annual | recover (numeric title) | ✓ |
| 115887 | Hellboy Winter Special 2018 | recover (year-in-title) | ✓ |
| 94592 | Zombie Tramp Halloween Special 2016 | recover (year-in-title) | ✓ |
| 99420 | Transformers Annual 2017 | recover (year-in-title) | ✓ |
| 101196 | Jungle Fantasy Annual 2017 | recover (year-in-title) | ✓ |
| 27490 | DC One Million 80-Page Giant | regress (issue#=1000000) | ✓ (unchanged) |
| 120754 | Transformers '84 | regress (issue#=0) | ✓ (unchanged) |

Validates: bypass fires correctly on the trap cases, doesn't regress
weird-issue-number cases, doesn't touch multi-issue Print series at all
(`Have/Total > 1` causes guard to fail; parser runs as before).

Subsequent broader bulk recheck on 16 single-volume cases from a Phase 4
audit: 18 stuck issues auto-recovered, zero regressions across the rest
of the collection.

## Related dormant issue

`MylarComics/mylar3#1212` describes a related but different sub-bug:
filename-keyword HC/GN branches don't apply the volume-as-issue trick that
TPB does. That fires only when the keyword is in the filename string. The
patch in this PR is the more general fix — it consults the comic's Type
field (which is always set if the user has classified the series correctly)
and bypasses the parser entirely for single-volume Type series. Could
optionally also close out #1212.
