### PR TITLE
fix: catch network errors in DDL downloaders to prevent thread death

### DIFF
--- a/mylar/downloaders/mediafire.py
+++ b/mylar/downloaders/mediafire.py
@@ -44,13 +44,17 @@ class MediaFire(object):
         url_origin = url
 
         while True:
-            t = self.session.get(
-                    url,
-                    verify=True,
-                    headers=self.headers,
-                    stream=True,
-                    timeout=(30,30)
-                )
+            try:
+                t = self.session.get(
+                        url,
+                        verify=True,
+                        headers=self.headers,
+                        stream=True,
+                        timeout=(30,30)
+                    )
+            except requests.exceptions.RequestException as e:
+                logger.warn('[MediaFire] Network error: %s' % e)
+                return {"success": False, "filename": None, "path": None, "link_type_failure": 'GC-Media'}
 
             if 'Content-Disposition' in t.headers:
                 # This is the file

--- a/mylar/downloaders/pixeldrain.py
+++ b/mylar/downloaders/pixeldrain.py
@@ -57,13 +57,17 @@ class PixelDrain(object):
                 return {"success": False, "filename": None, "path": None, "link_type_failure": 'GC-Pixel'}
 
 
-        t = self.session.get(
-                self.url,
-                verify=True,
-                headers=self.headers,
-                stream=True,
-                timeout=(30,30)
-            )
+        try:
+            t = self.session.get(
+                    self.url,
+                    verify=True,
+                    headers=self.headers,
+                    stream=True,
+                    timeout=(30,30)
+                )
+        except requests.exceptions.RequestException as e:
+            logger.warn('[PixelDrain] Network error resolving link: %s' % e)
+            return {"success": False, "filename": None, "path": None, "link_type_failure": 'GC-Pixel'}
 
         file_id = os.path.basename(
             urllib.parse.unquote(t.url)
@@ -73,7 +77,11 @@ class PixelDrain(object):
         logger.fdebug('[PixelDrain] file_id: %s' % file_id)
 
         logger.fdebug('[PixelDrain] retrieving info for file_id: %s' % file_id)
-        f_info = self.session.get(f"https://pixeldrain.com/api/file/{file_id}/info", verify=True, headers=self.headers,stream=True)
+        try:
+            f_info = self.session.get(f"https://pixeldrain.com/api/file/{file_id}/info", verify=True, headers=self.headers,stream=True)
+        except requests.exceptions.RequestException as e:
+            logger.warn('[PixelDrain] Network error fetching file info: %s' % e)
+            return {"success": False, "filename": None, "path": None, "link_type_failure": 'GC-Pixel'}
         if f_info.status_code == 200:
             info = f_info.json()
             logger.fdebug('[PixelDrain] pixeldrain_info_response: %s' % info)


### PR DESCRIPTION
This change was written using Claude Code (AI), under my direct supervision. I reviewed every line. I built the Docker image via GitHub Actions and tested in my personal Mylar deployment to confirm it addresses the failures I had been seeing.

A transient DNS failure (`socket.gaierror`) in `pixeldrain.ddl_download` propagated uncaught, killing the DDL-QUEUE worker thread and stalling all pending downloads until a container restart. Wraps the `session.get()` calls in both `pixeldrain.py` and `mediafire.py` in `try/except requests.exceptions.RequestException` blocks so network errors log a warning and return the standard failure dict instead of taking down the thread. The same gap existed in `mediafire.ddl_download` so both are fixed together.