### PR TITLE
Improve add-comic feedback and search filters

### DIFF
--- a/data/interfaces/carbon/css/data_table.css
+++ b/data/interfaces/carbon/css/data_table.css
@@ -42,6 +42,27 @@
 	    font-size: 15px;
 	    padding: 2px 4px;
 }
+#searchresults_table_filter {
+	width: 100%;
+	display: flex;
+	align-items: center;
+}
+#searchresults_table_filter #checkboxControls {
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+	margin-right: auto;
+	vertical-align: middle;
+	white-space: nowrap;
+}
+#searchresults_table .adding-comic {
+	white-space: nowrap;
+}
+#searchresults_table .adding-comic .ui-icon {
+	display: inline-block;
+	position: relative;
+	top: 3px;
+}
 .dataTables_info {
 	width: 50%;
 	float: left;

--- a/data/interfaces/carbon/css/managecomics.css
+++ b/data/interfaces/carbon/css/managecomics.css
@@ -1,0 +1,75 @@
+#markcomics .action-buttons,
+#markissues .action-buttons {
+    margin-bottom: 12px;
+}
+#markcomics .action-label,
+#markissues .action-label {
+    display: block;
+    font-weight: bold;
+    margin-bottom: 6px;
+}
+#markcomics .action-button-group,
+#markissues .action-button-group {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+#markcomics .action-row,
+#markissues .action-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+#markcomics .manage-action,
+#markissues .manage-action {
+    flex: 1;
+    min-width: 160px;
+    text-align: center;
+}
+#markcomics .manage-action[data-action="delete"] {
+    background-color: #a94442;
+}
+#markcomics .selected-counter,
+#markissues .selected-counter {
+    margin-top: 10px;
+    font-weight: bold;
+}
+#action-confirm,
+#issue-action-confirm {
+    margin-top: 12px;
+    padding: 10px;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.08);
+}
+#action-confirm.hidden,
+#issue-action-confirm.hidden {
+    display: none;
+}
+#action-confirm .action-confirm-buttons,
+#issue-action-confirm .action-confirm-buttons {
+    margin-top: 8px;
+    display: flex;
+    gap: 10px;
+}
+#action-confirm .action-confirm-buttons input[type="button"],
+#issue-action-confirm .action-confirm-buttons input[type="button"] {
+    flex: 0 0 120px;
+}
+
+.manage-switch-links {
+    margin-top: 10px;
+}
+
+.manage-switch-links a {
+    display: inline-block;
+    padding: 6px 10px;
+    background: #2d7bf4;
+    color: #fff;
+    border-radius: 3px;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.manage-switch-links a:hover {
+    background: #1e5ec0;
+}

--- a/data/interfaces/default/css/data_table.css
+++ b/data/interfaces/default/css/data_table.css
@@ -42,6 +42,27 @@
 	    font-size: 15px;
 	    padding: 2px 4px;
 }
+#searchresults_table_filter {
+	width: 100%;
+	display: flex;
+	align-items: center;
+}
+#searchresults_table_filter #checkboxControls {
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+	margin-right: auto;
+	vertical-align: middle;
+	white-space: nowrap;
+}
+#searchresults_table .adding-comic {
+	white-space: nowrap;
+}
+#searchresults_table .adding-comic .ui-icon {
+	display: inline-block;
+	position: relative;
+	top: 2px;
+}
 .dataTables_info {
 	width: 50%;
 	float: left;

--- a/data/interfaces/default/css/managecomics.css
+++ b/data/interfaces/default/css/managecomics.css
@@ -1,0 +1,75 @@
+#markcomics .action-buttons,
+#markissues .action-buttons {
+    margin-bottom: 12px;
+}
+#markcomics .action-label,
+#markissues .action-label {
+    display: block;
+    font-weight: bold;
+    margin-bottom: 6px;
+}
+#markcomics .action-button-group,
+#markissues .action-button-group {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+#markcomics .action-row,
+#markissues .action-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+#markcomics .manage-action,
+#markissues .manage-action {
+    flex: 1;
+    min-width: 160px;
+    text-align: center;
+}
+#markcomics .manage-action[data-action="delete"] {
+    background-color: #a94442;
+}
+#markcomics .selected-counter,
+#markissues .selected-counter {
+    margin-top: 10px;
+    font-weight: bold;
+}
+#action-confirm,
+#issue-action-confirm {
+    margin-top: 12px;
+    padding: 10px;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.08);
+}
+#action-confirm.hidden,
+#issue-action-confirm.hidden {
+    display: none;
+}
+#action-confirm .action-confirm-buttons,
+#issue-action-confirm .action-confirm-buttons {
+    margin-top: 8px;
+    display: flex;
+    gap: 10px;
+}
+#action-confirm .action-confirm-buttons input[type="button"],
+#issue-action-confirm .action-confirm-buttons input[type="button"] {
+    flex: 0 0 120px;
+}
+
+.manage-switch-links {
+    margin-top: 10px;
+}
+
+.manage-switch-links a {
+    display: inline-block;
+    padding: 6px 10px;
+    background: #2d7bf4;
+    color: #fff;
+    border-radius: 3px;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.manage-switch-links a:hover {
+    background: #1e5ec0;
+}

--- a/data/interfaces/default/managecomics.html
+++ b/data/interfaces/default/managecomics.html
@@ -17,27 +17,40 @@
 	<div id="manageheader" class="title">
 		<h1 class="clearfix">Manage comics</h1>
 	</div>
-	<form action="markComics" method="post" id="markComics">
-        <div id="markcomics" style="top:0;">
-		<select name="action" onChange="doAjaxCall('markComics',$(this),'table',true,'post');" data-error="You didn't select any comics">
-  			<option disabled="disabled" selected="selected">Choose...</option>
-  			<option value="delete">Delete Series</option>
-                        <option value="metatag">MetaTag Series</option>
-                        <option value="pause">Pause Series</option>
-  			<option value="recheck">Recheck Files</option>
-  			<option value="refresh">Refresh Series</option>
-			<option value="rename">Rename Series</option>
-  			<option value="resume">Resume Series</option>
-		</select>
-		selected comics
-		<input type="hidden" value="Go">
+	<form action="markComics" method="post" id="markComics" data-success="Action submitted. Watch the logs for progress." data-error="You didn't select any comics.">
+	        <div id="markcomics" style="top:0;">
+        <div class="action-buttons" aria-live="polite">
+            <span class="action-label">Choose an action for your selected comics:</span>
+            <div class="action-button-group">
+                <div class="action-row">
+                    <input type="button" class="manage-action" data-action="metatag" data-label="MetaTag Series" value="MetaTag Series">
+                    <input type="button" class="manage-action" data-action="pause" data-label="Pause Series" value="Pause Series">
+                    <input type="button" class="manage-action" data-action="recheck" data-label="Recheck Files" value="Recheck Files">
+                    <input type="button" class="manage-action" data-action="refresh" data-label="Refresh Series" value="Refresh Series">
+                </div>
+                <div class="action-row">
+                    <input type="button" class="manage-action" data-action="rename" data-label="Rename Series" value="Rename Series">
+                    <input type="button" class="manage-action" data-action="resume" data-label="Resume Series" value="Resume Series">
+                    <input type="button" class="manage-action" data-action="delete" data-label="Delete Series" value="Delete Series">
+                </div>
+            </div>
+        </div>
+	        <div id="action-confirm" class="action-confirm hidden">
+	            <span id="action-confirm-message"></span>
+	            <div class="action-confirm-buttons">
+	                <input type="button" id="action-confirm-yes" value="Yes">
+	                <input type="button" id="action-confirm-no" value="No">
+	            </div>
+	        </div>
+	        <div class="selected-counter">Selected comics: <span id="selected-count">0</span></div>
+		<input type="hidden" name="action" id="manage_action" value="">
 	</div>
 	<div class="table_wrapper">
 
 	<table class="display" id="manage_comic">
 		<thead>
 			<tr>
-				<th id="select"><input type="checkbox" onClick="toggle(this)" /></th>
+				<th id="select"><input type="checkbox" onClick="toggle(this);updateSelectedCount();" /></th>
 				<th id="albumart"></th>
 				<th id="name">Comic Name</th>
 				<th id="status">Status</th>
@@ -70,7 +83,7 @@
                                         grade = 'A'
                         %>
 			<tr>
-				<td id="select"><input type="checkbox" name="${comic['ComicName']}[${comic['ComicYear']}]" value="${comic['ComicID']}" class="checkbox" /></td>
+				<td id="select"><input type="checkbox" name="${comic['ComicName']}[${comic['ComicYear']}]" value="${comic['ComicID']}" class="checkbox" onchange="updateSelectedCount()" /></td>
 				<td id="albumart"><div><img src="${comic['ComicImage']}" height="75" width="50"></div></td>
 				<td id="name"><span title="${comic['ComicSortName']}"></span><a href="comicDetails?ComicID=${comic['ComicID']}">${comic['ComicName']} (${comic['ComicYear']})</a></td>
 				<td id="status">${comic['recentstatus']}</td>
@@ -100,6 +113,7 @@
 
 <%def name="headIncludes()">
 	<link rel="stylesheet" href="interfaces/${interface}/css/data_table.css">
+        <link rel="stylesheet" href="interfaces/${interface}/css/managecomics.css">
 </%def>
 
 <%def name="javascriptIncludes()">
@@ -108,6 +122,42 @@
 	<script>
 
         var lastChecked = null;
+        var pendingAction = null;
+
+        function updateSelectedCount() {
+                var count = $("#manage_comic input.checkbox:checked").length;
+                $("#selected-count").text(count);
+                return count;
+        }
+
+        function showConfirm(action, label) {
+                var count = updateSelectedCount();
+                if (count === 0) {
+                        var errorMsg = $(".action-buttons").attr('data-error') || "Pick at least one comic first.";
+                        alert(errorMsg);
+                        pendingAction = null;
+                        return;
+                }
+                pendingAction = action;
+                var message = label + '? You selected ' + count + (count === 1 ? ' series.' : ' series.');
+                $('#action-confirm-message').text(message);
+                $('#action-confirm').removeClass('hidden');
+        }
+
+        function hideConfirm() {
+                pendingAction = null;
+                $('#action-confirm').addClass('hidden');
+        }
+
+        function submitAction() {
+                if (!pendingAction) {
+                        return;
+                }
+                $('#manage_action').val(pendingAction);
+                doAjaxCall('markComics',$('#markComics'),'table',true,'post');
+                hideConfirm();
+        }
+
         function initThisPage() {
                 $.fn.DataTable.ext.pager.numbers_length = 5;
                 $('#manage_comic').dataTable( {
@@ -118,7 +168,7 @@
                             { 'bSortable': false, 'aTargets': [ 0, 1 ] },
                             { 'order': [[2, 'desc'],[3, 'desc']] }
                         ],
-                        "lengthMenu": [[10, 25, 50, -1], [10, 25, 50, 'All' ]],
+                        "lengthMenu": [[10, 25, 50, 100, 200, 500, -1], [10, 25, 50, 100, 200, 500, 'All' ]],
                         "language": {
                                 "lengthMenu":"Show _MENU_ results per page",
                                 "emptyTable": "No results",
@@ -154,7 +204,21 @@
                                 lastChecked = this;
                             }
                         }
+                        updateSelectedCount();
                     });
+                $('.manage-action').on('click', function(){
+                        var action = $(this).data('action');
+                        var label = $(this).data('label') || $(this).text();
+                        showConfirm(action, label);
+                });
+
+                $('#action-confirm-yes').on('click', function(){
+                        submitAction();
+                });
+
+                $('#action-confirm-no').on('click', function(){
+                        hideConfirm();
+                });
         }
 
         $(document).ready(function(){

--- a/data/interfaces/default/manageissues.html
+++ b/data/interfaces/default/manageissues.html
@@ -34,18 +34,30 @@
                 <input type="submit" value="Manage">
         </div>
         </form>
-        </br></br>
-	<form action="markissues" method="post" id="markissues">
-        <div id="markissues" style="top:0;">
-		<select name="action" onChange="doAjaxCall('markissues',$(this),'table',true,'post');" data-error="You didn't select any issues">
-  			<option disabled="disabled" selected="selected">Choose...</option>
-  			<option value="Wanted">Wanted</option>
-  			<option value="Archived">Archived</option>
-  			<option value="Skipped">Skipped</option>
-  			<option value="Ignored">Ignored</option>
-		</select>
-                selected issues
-		<input type="hidden" value="Go">
+	<form action="markissues" method="post" id="markissues" data-success="Updated issue status successfully." data-error="You didn't select any issues.">
+        <div id="markissues_container" style="top:0;">
+        <div class="action-buttons" aria-live="polite">
+            <span class="action-label">Choose what to do with your selected issues:</span>
+            <div class="action-button-group">
+                <div class="action-row">
+                    <input type="button" class="manage-action issue-action" data-action="Wanted" data-label="Mark as Wanted" value="Mark as Wanted">
+                    <input type="button" class="manage-action issue-action" data-action="Archived" data-label="Mark as Archived" value="Mark as Archived">
+                </div>
+                <div class="action-row">
+                    <input type="button" class="manage-action issue-action" data-action="Skipped" data-label="Mark as Skipped" value="Mark as Skipped">
+                    <input type="button" class="manage-action issue-action" data-action="Ignored" data-label="Mark as Ignored" value="Mark as Ignored">
+                </div>
+            </div>
+        </div>
+        <div id="issue-action-confirm" class="action-confirm hidden">
+            <span id="issue-action-confirm-message"></span>
+            <div class="action-confirm-buttons">
+                <input type="button" id="issue-action-confirm-yes" value="Yes">
+                <input type="button" id="issue-action-confirm-no" value="No">
+            </div>
+        </div>
+        <div class="selected-counter">Selected issues: <span id="issue-selected-count">0</span></div>
+        <input type="hidden" name="action" id="manage_issue_action" value="">
 	</div>
         
 	<div class="table_wrapper">
@@ -53,7 +65,7 @@
 	<table class="display" id="manage_issues">
 		<thead>
 			<tr>
-				<th id="select"><input type="checkbox" onClick="toggle(this)" class="checkbox" align="left" /></th>
+				<th id="select"><input type="checkbox" onClick="toggle(this);updateIssueSelectedCount();" class="checkbox" align="left" /></th>
 				<th id="name">Series</th>
                                 <th id="int_issue">Int_Issue</th>
 				<th id="issue">Issue</th>
@@ -66,7 +78,7 @@
 		<tbody>
 		%for issue in issues:
 			<tr>
-				<td id="select"><input type="checkbox" name="${issue['IssueID']}" class="checkbox" /></td>
+				<td id="select"><input type="checkbox" name="${issue['IssueID']}" class="checkbox" onchange="updateIssueSelectedCount()" /></td>
                                 <% 
                                      try:
                                          if issue['ReleaseComicName']:
@@ -107,15 +119,52 @@
 
 <%def name="headIncludes()">
 	<link rel="stylesheet" href="interfaces/${interface}/css/data_table.css">
+        <link rel="stylesheet" href="interfaces/${interface}/css/managecomics.css">
 </%def>
 
 <%def name="javascriptIncludes()">
 	<script src="js/libs/jquery.dataTables.min.js"></script>
-        <script>
-        
+	<script>
+
         var lastChecked = null;
+        var issuePendingAction = null;
+
+        function updateIssueSelectedCount() {
+                var count = $("#manage_issues input.checkbox:checked").length;
+                $("#issue-selected-count").text(count);
+                return count;
+        }
+
+        function showIssueConfirm(action, label) {
+                var count = updateIssueSelectedCount();
+                if (count === 0) {
+                        var errorMsg = $("#markissues .action-buttons").attr('data-error') || "Select at least one issue.";
+                        alert(errorMsg);
+                        issuePendingAction = null;
+                        return;
+                }
+                issuePendingAction = action;
+                var msg = label + ' (' + count + (count === 1 ? ' issue selected)' : ' issues selected)');
+                $('#issue-action-confirm-message').text(msg);
+                $('#issue-action-confirm').removeClass('hidden');
+        }
+
+        function hideIssueConfirm() {
+                issuePendingAction = null;
+                $('#issue-action-confirm').addClass('hidden');
+        }
+
+        function submitIssueAction() {
+                if (!issuePendingAction) {
+                        return;
+                }
+                $('#manage_issue_action').val(issuePendingAction);
+                doAjaxCall('markissues',$('#markissues'),'table',true,'post');
+                hideIssueConfirm();
+        }
         
         function initThisPage() {
+                updateIssueSelectedCount();
                 $('#manage_issues').dataTable(
                         {
                                 "bDestroy": true,
@@ -125,7 +174,7 @@
                                   { 'sType': 'numeric', 'aTargets': [2] },
                                   { 'columns.orderData': [2], 'aTargets': [3] }
                                 ],
-                                "aLengthMenu": [[10, 25, 50, -1], [10, 25, 50, 'All' ]],
+                                "aLengthMenu": [[10, 25, 50, 100, 200, 500, -1], [10, 25, 50, 100, 200, 500, 'All' ]],
                                 "oLanguage": {
                                         "sLengthMenu":"Show _MENU_ results per page",
                                         "sEmptyTable": "No results",
@@ -161,7 +210,19 @@
                                 lastChecked = this;
                                 }
                         }
+                        updateIssueSelectedCount();
                         });
+                $('.issue-action').on('click', function(){
+                        var action = $(this).data('action');
+                        var label = $(this).data('label') || $(this).text();
+                        showIssueConfirm(action, label);
+                });
+                $('#issue-action-confirm-yes').on('click', function(){
+                        submitIssueAction();
+                });
+                $('#issue-action-confirm-no').on('click', function(){
+                        hideIssueConfirm();
+                });
         }
 
         $(document).ready(function(){

--- a/data/interfaces/default/searchresults.html
+++ b/data/interfaces/default/searchresults.html
@@ -61,7 +61,7 @@
         <div class="table_wrapper" id="search_wrapper">
 
             %if search_type != 'story_arc':
-            <div id="checkboxControls" name="checkboxControls" style="float:right;vertical-align:middle;margin:5px 3px 8px 3px;">
+            <div id="checkboxControls" name="checkboxControls" style="display:none;">
                 <label for="hide_already" class="checkbox inline">
                     <input type="checkbox" name="hide_already" id="hide_already" /> Hide already in library
                 </label>
@@ -401,6 +401,14 @@
 
         var lastChecked = null;
 
+        function placeSearchFilters(){
+            var checkboxControls = $('#checkboxControls');
+            var filter = $('#searchresults_table_filter');
+            if (checkboxControls.length && filter.length) {
+                checkboxControls.prependTo(filter).css('display', 'inline-flex');
+            }
+        }
+
         function initThisPage(){
                 initActions();
                 var search_type = "${search_type}";
@@ -544,6 +552,7 @@
                      "drawCallback": function (settings) {
                          // Jump to top of page
                          $('#searchresults_table div.dataTables_scrollBody').scrollTop(pageScrollPos);
+                         placeSearchFilters();
                      },
                      "serverData": function ( sSource, aoData, fnCallback ) {
                                 /* Add some extra data to the sender */
@@ -556,8 +565,11 @@
                      },
                      "fnInitComplete": function(oSettings, json)
                      {
+                         placeSearchFilters();
                      },
                 });
+
+                placeSearchFilters();
 
                 $('#searchresults_table tbody').on('click', 'input[type="checkbox"]', function(e){
                 var chkboxes = Array.from($(":checkbox"));

--- a/data/interfaces/default/searchresults.html
+++ b/data/interfaces/default/searchresults.html
@@ -60,6 +60,17 @@
 
         <div class="table_wrapper" id="search_wrapper">
 
+            %if search_type != 'story_arc':
+            <div id="checkboxControls" name="checkboxControls" style="float:right;vertical-align:middle;margin:5px 3px 8px 3px;">
+                <label for="hide_already" class="checkbox inline">
+                    <input type="checkbox" name="hide_already" id="hide_already" /> Hide already in library
+                </label>
+                <label for="hide_tpb" class="checkbox inline">
+                    <input type="checkbox" name="hide_tpb" id="hide_tpb" /> Hide TPB
+                </label>
+            </div>
+            %endif
+
             <form action="mark_the_results" method="get" id="markresults" name="markresults">
                <div style="position:absolute;float:left;display:none;" id="markresult">Mark selected series as
                     <select name="action" id="mark_results" onChange="mark_the_results()">
@@ -154,6 +165,31 @@
             });
         }
 
+        var addingComics = {};
+
+        function addingComicMarkup(){
+            return '<span class="adding-comic"><span class="ui-icon ui-icon-clock"></span>Adding comic</span>';
+        }
+
+        function markComicAdding(comicid){
+            addingComics[String(comicid)] = true;
+            var table = $('#searchresults_table').DataTable();
+
+            table.rows().every(function(){
+                var rowData = this.data();
+                if (rowData && String(rowData[0]) === String(comicid)) {
+                    rowData[9] = 'Adding';
+                    this.data(rowData);
+                    if (this.child.isShown()) {
+                        this.child.hide();
+                    }
+                    var rowNode = this.node();
+                    $(rowNode).removeClass('shown gradeY');
+                    $('td:last', rowNode).html(addingComicMarkup());
+                }
+            });
+        }
+
         function addseries(comicid, query_id, com_location, booktype){
             //var markupcoming = document.getElementById("markupcoming").checked;
             //var markall = document.getElementById("markall").checked;
@@ -165,19 +201,34 @@
                 booktype = null;
             }
             console.log('com_location:'+com_location);
-            $.when($.ajax({
+
+            if (addingComics[String(comicid)]) {
+                return false;
+            }
+
+            var addLink = $('#addbyid_' + comicid);
+            var spinner = $('#loading_spinner_' + comicid);
+            addLink.attr('aria-disabled', 'true').css('pointer-events', 'none');
+            spinner.show();
+
+            return $.ajax({
                  type: "GET",
                  url: "addbyid",
+                 dataType: "json",
                  data: { comicid: comicid, query_id: query_id, com_location: com_location, booktype: booktype}, //, markupcoming: markupcoming, markall: markall},
-                 success: function(response) {
-                    //obj = JSON.parse(response);
-                 },
-                 error: function(data)
-                     {
-                       alert('ERROR'+data.responseText);
-                     },
-            })).done(function(data) {
-                 //reload_table();
+            }).done(function(response) {
+                 if (response && response.status === 'success') {
+                     markComicAdding(comicid);
+                 } else {
+                     alert('ERROR: ' + ((response && response.message) || 'Unable to queue this comic.'));
+                 }
+            }).fail(function(data) {
+                 alert('ERROR: ' + (data.responseText || 'Unable to queue this comic.'));
+            }).always(function() {
+                 spinner.hide();
+                 if (!addingComics[String(comicid)]) {
+                     addLink.removeAttr('aria-disabled').css('pointer-events', '');
+                 }
             });
         }
 
@@ -438,12 +489,15 @@
                                        displayline = '<a id="alreadyhave" name="alreadyhave" href="detailStoryArc?StoryArcID=' + full[0] + '&StoryArcName=' + full[1] + '"><span class="ui-icon ui-icon-arrowreturnthick-1-n"></span>Already in Library</a>';
                                    }
                                } else {
-                                   if (full[9] === "No") {
+                                   if (full[9] === "Yes") {
+                                       delete addingComics[String(full[0])];
+                                       displayline = '<a id="alreadyhave" name="alreadyhave" href="comicDetails?ComicID=' + full[0] + '"><span class="ui-icon ui-icon-arrowreturnthick-1-n"></span>Already in Library</a>';
+                                   } else if (full[9] === "Adding" || addingComics[String(full[0])]) {
+                                       displayline = addingComicMarkup();
+                                   } else {
                                        displayline = '<a id="extend_detail" name="extend_detail" href="#"><span class="ui-icon ui-icon-plus"></span>Edit</a>';
                                        displayline += '<a id="addbyid_'+full[0]+'" name="addbyid" href="#"><span class="ui-icon ui-icon-plus"></span>Add this Comic</a>';
                                        displayline += '<span id="loading_spinner_'+full[0]+'" style="display:none;float:right;"><img src="images/loader_black.gif"  height="20" width="20" alt="loading"/></span>';
-                                   } else {
-                                       displayline = '<a id="alreadyhave" name="alreadyhave" href="comicDetails?ComicID=' + full[0] + '"><span class="ui-icon ui-icon-arrowreturnthick-1-n"></span>Already in Library</a>';
                                    }
                                }
                                return displayline;
@@ -463,17 +517,18 @@
                          "infoFiltered":"(filtered from _MAX_ total issues)"
                     },
                     "rowCallback": function (nRow, aData, iDisplayIndex, iDisplayIndexFull) {
+                        var inLibrary = aData[9] === "Yes";
                         if (aData[7] === "Digital" || aData[7] === "TPB" || aData[7] === "GN" || aData[7] == "HC") {
-                            if (aData[9] === "No") {
-                                $('td', nRow).closest('tr').addClass("gradeZ");
-                            } else {
+                            if (inLibrary) {
                                 $('td', nRow).closest('tr').addClass("gradeH");
+                            } else {
+                                $('td', nRow).closest('tr').addClass("gradeZ");
                             }
                          } else {
-                            if (aData[9] === "No") {
-                                $('td', nRow).closest('tr').addClass("gradeB");
-                            } else {
+                            if (inLibrary) {
                                 $('td', nRow).closest('tr').addClass("gradeH");
+                            } else {
+                                $('td', nRow).closest('tr').addClass("gradeB");
                             }
                          }
                          nRow.children[0].id = 'select';
@@ -493,6 +548,8 @@
                      "serverData": function ( sSource, aoData, fnCallback ) {
                                 /* Add some extra data to the sender */
                                 aoData.push({"name": "search_query", "value": retrieve_searchquery() });
+                                aoData.push({"name": "hide_already", "value": $('#hide_already').is(':checked') ? "1" : "0" });
+                                aoData.push({"name": "hide_tpb", "value": $('#hide_tpb').is(':checked') ? "1" : "0" });
                                 $.getJSON(sSource, aoData, function (json) {
                                         fnCallback(json)
                                 });

--- a/mylar/webserve.py
+++ b/mylar/webserve.py
@@ -1071,7 +1071,7 @@ class WebInterface(object):
         })
     loadAnnualDetails.exposed = True
 
-    def loadSearchResults(self, query=None, iDisplayStart=0, iDisplayLength=25, iSortCol_0='1', sSortDir_0="desc", sSearch="", **kwargs):
+    def loadSearchResults(self, query=None, iDisplayStart=0, iDisplayLength=25, iSortCol_0='1', sSortDir_0="desc", sSearch="", hide_already='0', hide_tpb='0', **kwargs):
 
         logger.fdebug('query: %s' % query)
         if query is None:
@@ -1079,7 +1079,12 @@ class WebInterface(object):
             logger.fdebug('search_query: %s' % query)
 
         myDB = db.DBConnection()
-        queryline = "SELECT * FROM tmp_searches WHERE query_id=?" # ORDER BY %s" % sortcolumn
+        queryline = """
+            SELECT tmp_searches.*, comics.Status AS library_status
+            FROM tmp_searches
+            LEFT JOIN comics ON comics.ComicID = tmp_searches.comicid
+            WHERE tmp_searches.query_id=?
+        """
         db_results = myDB.select(queryline, [query])
         if not db_results:
             try:
@@ -1104,7 +1109,7 @@ class WebInterface(object):
                                 'url': rt['url'],
                                 'type': rt['type'],
                                 'description': rt['description'],
-                                'haveit': rt['haveit'],
+                                'haveit': 'Yes' if rt['haveit'] == 'Adding' and rt['library_status'] == 'Active' else rt['haveit'],
                                 'query_id': rt['query_id']})
 
         if not results:
@@ -1113,6 +1118,7 @@ class WebInterface(object):
                 'iTotalRecords': 0,
                 'aaData': [],
             })
+        total_records = len(results)
         if sSearch == "" or sSearch == None:
             filtered = results[::]
         else:
@@ -1156,6 +1162,13 @@ class WebInterface(object):
                 except Exception as e:
                     pass
 
+        hide_already = str(hide_already).lower() in ('1', 'true', 'yes', 'on')
+        hide_tpb = str(hide_tpb).lower() in ('1', 'true', 'yes', 'on')
+        if hide_already:
+            filtered = [row for row in filtered if row['haveit'] != 'Yes']
+        if hide_tpb:
+            filtered = [row for row in filtered if (row['type'] or '').upper() != 'TPB']
+
         sortcolumn = 'comicname'
         if iSortCol_0 == '1':
             sortcolumn = 'comicname'
@@ -1172,6 +1185,7 @@ class WebInterface(object):
             filtered.sort(key=lambda x: (x[sortcolumn] is None, x[sortcolumn] == '', x[sortcolumn]), reverse=sSortDir_0 == "desc")
 
         logger.info('# of results: %s' % len(filtered))
+        total_display_records = len(filtered)
         iDisplayStart = int(iDisplayStart)
         iDisplayLength = int(iDisplayLength)
         # -1 is used for "All" in DataTables filters
@@ -1180,8 +1194,8 @@ class WebInterface(object):
         rows = [[row['comicid'], row['comicname'], row['publisher'], row['comicyear'], row['issues'], row['deck'], row['url'], row['type'], row['description'], row['haveit'], row['query_id']] for row in filtered]
 
         return json.dumps({
-            'iTotalDisplayRecords': len(results), #len(filtered),
-            'iTotalRecords': len(results),
+            'iTotalDisplayRecords': total_display_records,
+            'iTotalRecords': total_records,
             'aaData': rows,
         })
     loadSearchResults.exposed = True
@@ -1541,6 +1555,8 @@ class WebInterface(object):
                             'Total': comicinfo['ComicIssues']}
                     myDB.upsert( "comics", vals, {'ComicID': comicid} )
 
+        queue_error = None
+        queue_status = 'already_queued'
         if nothread is False:
             watch = []
             #if not any(ext['comicid'] == ComicID for ext in mylar.REFRESH_LIST):
@@ -1558,12 +1574,35 @@ class WebInterface(object):
                 logger.info('[SHIZZLE-WHIZZLE] Now queueing to add %s' % (og_line))
                 try:
                     importer.importer_thread(watch)
-                except Exception:
-                    pass
+                except Exception as e:
+                    queue_error = e
+                    logger.error('Unable to queue %s for addition: %s' % (og_line, e))
+                else:
+                    queue_status = 'queued'
 
             #threading.Thread(target=importer.addComictoDB, args=[comicid, mismatch, None, imported, ogcname]).start()
         else:
             return importer.addComictoDB(comicid, mismatch, None, imported, ogcname)
+
+        if query_id is not None and (calledby is True or calledby == 'True'):
+            if queue_error is not None:
+                return json.dumps({
+                    'status': 'failure',
+                    'message': 'Unable to queue this comic. Please check the logs.'
+                })
+
+            myDB.upsert(
+                'tmp_searches',
+                {'haveit': 'Adding'},
+                {'query_id': query_id, 'comicid': comicid}
+            )
+            return json.dumps({
+                'status': 'success',
+                'state': 'adding',
+                'queue_status': queue_status,
+                'comicid': comicid,
+                'message': 'Comic queued for addition.'
+            })
 
         if calledby is True or calledby == 'True':
            return


### PR DESCRIPTION
Adds a new "Adding Comic" status that persists across pagination and updates when the comic finishes getting added.
<img width="966" height="51" alt="image" src="https://github.com/user-attachments/assets/ae729558-038c-4c30-b6e3-3d1f8e8f65c3" />

Added filters to hide detected TPBs and hide comics already in the library 

https://github.com/user-attachments/assets/561ce5f3-5989-4e16-ac5e-77faaec648ce


Changed manage comics page to use buttons instead of dropdown, + a confirmation on deleting series, avoiding mistaken full library deletion which I have done 3 times at this point

<img width="1008" height="475" alt="image" src="https://github.com/user-attachments/assets/0aeb50e7-a565-4f1c-8470-ea99554dcce2" />

Also did the same to Manage Issues as I've made quite a few blunders there too

<img width="1011" height="253" alt="image" src="https://github.com/user-attachments/assets/7a3dae5e-9af2-459a-a6fb-367bbb98d7a4" />
