### PR TITLE
fix: use the right property from sabnzbd queue response

### DIFF
--- a/mylar/sabnzbd.py
+++ b/mylar/sabnzbd.py
@@ -99,7 +99,7 @@ class SABnzbd(object):
             queueresponse = h.json()
             logger.fdebug('successfully queried the queue for status')
             try:
-                if queueresponse['noofslots'] == 1: # 1 means it matched to one instance
+                if queueresponse['queue']['noofslots'] == 1: # 1 means it matched to one instance
                     queueinfo = queueresponse['queue']['slots'][0]
                     logger.info('monitoring ... detected download - %s [%s]' % (queueinfo['filename'], queueinfo['status']))
             except Exception as e:


### PR DESCRIPTION
Checks for the `noofslots` property on the `queue` property from the sabnzbd api call instead of the root of the returned json

Example response from `http://sabnzbd.sabnzbd.svc.cluster.local:8080/api?mode=queue&output=json&nzo_ids=<anyid>&apikey=<validApiKey>`:

```json
{
  "queue": {
    "version": "5.0.4",
    "paused": false,
    "pause_int": "0",
    "paused_all": false,
    "diskspace1": "50720.16",
    "diskspace2": "50720.16",
    "diskspace1_norm": "49.5 T",
    "diskspace2_norm": "49.5 T",
    "diskspacetotal1": "55839.35",
    "diskspacetotal2": "55839.35",
    "speedlimit": "0",
    "speedlimit_abs": "0",
    "have_warnings": "0",
    "finishaction": null,
    "quota": "0 B",
    "have_quota": false,
    "left_quota": "0 B",
    "cache_art": "0",
    "cache_size": "0 B",
    "kbpersec": "0.00",
    "speed": "0",
    "mbleft": "0.00",
    "mb": "0.00",
    "sizeleft": "0 B",
    "size": "0 B",
    "noofslots_total": 0,
    "noofslots": 0,
    "start": 0,
    "limit": 0,
    "finish": 0,
    "status": "Idle",
    "timeleft": "0:00:00",
    "slots": []
  }
}
```

`noofslots` is inside of `queue`. Using `noofslots` directly on the root of the response would cause an exception, causing warning `Unable to locate item within sabnzbd active queue - it could be finished already?` to be logged instead of 
info log `monitoring ... detected download - %s [%s]' % (queueinfo['filename'], queueinfo['status'])`