### PR TITLE
fix: retain trailing year in series title when known ComicName confirms it

### DIFF
--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -1232,7 +1232,16 @@ class FileChecker(object):
         if yearposition != 0:
             if yearposition is not None and yearposition < highest_series_pos:
                 if yearposition+1 == highest_series_pos:
-                    highest_series_pos = yearposition
+                    #normally the year immediately preceding the issue number is a standalone
+                    #launch-year and not part of the title (eg. 'Batman 2016 001.cbz'), so it gets
+                    #stripped from the reconstructed series title. Some real series titles legitimately
+                    #end in a bare year though (eg. 'American Vampire 1976'), so only strip it here if
+                    #doing so wouldn't contradict the already-known series title (self.watchcomic).
+                    year_inclusive_name = ' '.join(split_file[:highest_series_pos])
+                    if self.watchcomic is not None and self.watchcomic.strip().lower() == year_inclusive_name.strip().lower():
+                        logger.fdebug('year (%s) matches the known series title (%s) - retaining as part of series title.' % (split_file[yearposition], self.watchcomic))
+                    else:
+                        highest_series_pos = yearposition
                 else:
                     if split_file[yearposition+1] == '-' and yearposition+2 == highest_series_pos:
                         highest_series_pos = yearposition

--- a/tests/test_filechecker.py
+++ b/tests/test_filechecker.py
@@ -76,3 +76,23 @@ def test_manual_filename_parsing(monkeypatch, filename, series, issue, year, vol
                 volume,
                 year,
                 issue))
+
+
+@pytest.mark.unit
+def test_series_title_with_trailing_year_retained_when_watchcomic_known(monkeypatch):
+    # Regression test: series whose real title ends in a bare (non-parenthesized) 4-digit
+    # number that looks like a year - e.g. "American Vampire 1976" (a real series title,
+    # not a year suffix) - must not have that trailing number silently dropped from the
+    # reconstructed series_name when the known series name (watchcomic) confirms it belongs
+    # there. forceRescan()/markissues()/refreshSeries() all pass the known ComicName in as
+    # watchcomic, so this context is available in the real failure case.
+    monkeypatch.setattr(mylar, "CONFIG", mylar.config.Config("./nothing"))
+    monkeypatch.setattr(mylar.CONFIG, "IGNORE_SEARCH_WORDS", [], raising=False)
+    monkeypatch.setattr(mylar.CONFIG, "CUSTOM_ISSUE_EXCEPTIONS", [], raising=False)
+
+    filename = "American Vampire 1976 007.cbz"
+    fc_obj = filechecker.FileChecker(watchcomic="American Vampire 1976", file=filename, justparse=True, manual=True)
+    parsed = fc_obj.parseit(path='/dummypath/', filename=filename)
+
+    assert parsed['series_name'] == "American Vampire 1976"
+    assert parsed['issue_number'] == "007"


### PR DESCRIPTION
Fixes #65